### PR TITLE
Change `api_key` configs type to `Password`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.5
+  - Change `api_key` config type to `Password` for better from protection from leaks in debug logs [#9](https://github.com/logstash-plugins/logstash-input-rackspace/pull/9)
+
 ## 3.0.4
   - Docs: Set the default_codec doc attribute.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -31,7 +31,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
-| <<plugins-{type}s-{plugin}-api_key>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-api_key>> |<<password,password>>|Yes
 | <<plugins-{type}s-{plugin}-claim>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-queue>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-region>> |<<string,string>>|No
@@ -48,7 +48,7 @@ input plugins.
 ===== `api_key` 
 
   * This is a required setting.
-  * Value type is <<string,string>>
+  * Value type is <<password,password>>
   * There is no default value for this setting.
 
 Rackspace Cloud API Key

--- a/lib/logstash/inputs/rackspace.rb
+++ b/lib/logstash/inputs/rackspace.rb
@@ -10,7 +10,7 @@ class LogStash::Inputs::Rackspace < LogStash::Inputs::Base
   config :username, :validate => :string, :required => true
   
   # Rackspace Cloud API Key
-  config :api_key, :validate => :string, :required => true
+  config :api_key, :validate => :password, :required => true
    
   # Rackspace region
   # `ord, dfw, lon, syd,` etc
@@ -32,7 +32,7 @@ class LogStash::Inputs::Rackspace < LogStash::Inputs::Base
     require "fog"
     @service = Fog::Rackspace::Queues.new(
       :rackspace_username  => @username,   # Your Rackspace Username
-      :rackspace_api_key   => @api_key,         # Your Rackspace API key
+      :rackspace_api_key   => @api_key.value,         # Your Rackspace API key
       :rackspace_region    => @region.to_sym,                  # Your desired region
       :connection_options  => {}                     # Optional connection options
     )

--- a/logstash-input-rackspace.gemspec
+++ b/logstash-input-rackspace.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-rackspace'
-  s.version         = '3.0.4'
+  s.version         = '3.0.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Pull events from rackspace cloud queue"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/rackspace_spec.rb
+++ b/spec/inputs/rackspace_spec.rb
@@ -1,1 +1,16 @@
 require "logstash/devutils/rspec/spec_helper"
+require "logstash/inputs/rackspace"
+
+describe LogStash::Inputs::Rackspace do
+
+  let(:plugin) { described_class.new(config) }
+
+  describe "debugging `api_key`" do
+    let(:config) {{ "username" => "user_name", "api_key" => "$ecre&-key" }}
+
+    it "should not show origin value" do
+      expect(plugin.logger).to receive(:debug).with('<password>')
+      plugin.logger.send(:debug, plugin.api_key.to_s)
+    end
+  end
+end


### PR DESCRIPTION
### Description
This PR ensures to protect the `:secret_token` from leaks in the debug logs.

- Closes #8 

### Test
```
# config
input {
  rackspace {
      api_key => "my-super-secret-api-key"
      username  => "mashhur"
  }
}
output {
    stdout {
        codec => rubydebug
    }
}
```

```
# Log before change
  [2022-12-05T15:45:19,516][DEBUG][logstash.inputs.rackspace] config LogStash::Inputs::Rackspace/@api_key = "my-super-secret-api-key"
  [2022-12-05T15:45:19,516][DEBUG][logstash.inputs.rackspace] config LogStash::Inputs::Rackspace/@username = "mashhur"

# Log after change
 [2022-12-05T16:10:19,203][DEBUG][logstash.inputs.rackspace] config LogStash::Inputs::Rackspace/@api_key = <password>
  [2022-12-05T16:10:19,203][DEBUG][logstash.inputs.rackspace] config LogStash::Inputs::Rackspace/@username = "mashhur"
```